### PR TITLE
Linux compatibility

### DIFF
--- a/EldenBingo/GameInterop/GameProcessHandler.cs
+++ b/EldenBingo/GameInterop/GameProcessHandler.cs
@@ -1010,7 +1010,9 @@ namespace EldenBingo.GameInterop
         /// </summary>
         public uint Execute(IntPtr address, uint timeout = 0xFFFFFFFF)
         {
-            var thread = WinAPI.CreateRemoteThread(_gameAccessHwnd, IntPtr.Zero, 0, address, IntPtr.Zero, 0, IntPtr.Zero);
+            IntPtr thread;
+            WinAPI.NtCreateThreadEx(out thread, 0x1FFFFF, IntPtr.Zero, _gameAccessHwnd, address, IntPtr.Zero, false, 0, 0, 0, IntPtr.Zero );
+            
             var result = WinAPI.WaitForSingleObject(thread, timeout);
             WinAPI.CloseHandle(thread);
             return result;

--- a/EldenBingo/GameInterop/WinAPI.cs
+++ b/EldenBingo/GameInterop/WinAPI.cs
@@ -91,8 +91,8 @@ namespace EldenBingo.GameInterop
         
         [DllImport("kernel32.dll")]
         public static extern uint WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
-        [DllImport("kernel32.dll")]
-        public static extern IntPtr CreateRemoteThread(IntPtr hProcess, IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);
+        [DllImport("ntdll.dll", SetLastError = true)]
+        public static extern int NtCreateThreadEx(out IntPtr threadHandle, uint desiredAccess, IntPtr objectAttributes, IntPtr processHandle, IntPtr startAddress, IntPtr parameter, bool createSuspended, int stackZeroBits, int sizeOfStackCommit, int sizeOfStackReserve, IntPtr bytesBuffer);
         [DllImport("kernel32.dll")]
         public static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr lpAddress, IntPtr dwSize, uint dwFreeType);
     }

--- a/EldenBingo/GameInterop/WinAPI.cs
+++ b/EldenBingo/GameInterop/WinAPI.cs
@@ -91,7 +91,7 @@ namespace EldenBingo.GameInterop
         
         [DllImport("kernel32.dll")]
         public static extern uint WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
-        [DllImport("ntdll.dll", SetLastError = true)]
+        [DllImport("ntdll.dll")]
         public static extern int NtCreateThreadEx(out IntPtr threadHandle, uint desiredAccess, IntPtr objectAttributes, IntPtr processHandle, IntPtr startAddress, IntPtr parameter, bool createSuspended, int stackZeroBits, int sizeOfStackCommit, int sizeOfStackReserve, IntPtr bytesBuffer);
         [DllImport("kernel32.dll")]
         public static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr lpAddress, IntPtr dwSize, uint dwFreeType);


### PR DESCRIPTION
Replaced CreateRemoteThread() with NtCreateThreadEx() because wine/proton can handle it better. Having a native Linux build would be nicer but that would require replacing WinForms.

I tested this for a full base game randomizer run with 2 players and for 2 short tests (one solo, one multiplayer) in DLC. The fog gate from Season 4 DLC bingo does disappear with this change. I could not test this under Windows.