### PR TITLE
Drop 60 fps cap that stalls the map window

### DIFF
--- a/EldenBingo/Rendering/SimpleGameWindow.cs
+++ b/EldenBingo/Rendering/SimpleGameWindow.cs
@@ -20,8 +20,9 @@ namespace EldenBingo.Rendering
         public SimpleGameWindow(string title, uint width, uint height, SFML.Window.Styles styles = SFML.Window.Styles.Default) :
             base(new SFML.Window.VideoMode(width, height), title, styles, new SFML.Window.ContextSettings() { MajorVersion = 1, MinorVersion = 3, AttributeFlags = SFML.Window.ContextSettings.Attribute.Default})
         {
+            //No SetFramerateLimit alongside this: its per-frame sleep overshoots badly, 292 ms
+            //stalls measured with vsync off. Vsync alone paces the loop.
             SetVerticalSyncEnabled(true);
-            SetFramerateLimit(60);
 
             GameObjects = new HashSet<object>();
             Updateables = new List<IUpdateable>();


### PR DESCRIPTION
I noticed on my machine with 144 hz screen the map stalls a lot so I investigated and have a fix for it.

Measured over 45s idle per configuration, steady state only:
```
                        mean     fps   >100ms    worst
  vsync + limiter    16.94 ms   59.0        3   302 ms
  limiter, vsync off 18.03 ms   55.5       13   292 ms
  vsync only          6.93 ms  144.2        0    10 ms
```
I tried with the configs above, but only vsync gives correct display. It would be great if you could try this change before accepting so it doesn't break on 60 hz, but I think it should be just fine.
